### PR TITLE
Add project files for translations lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
-# lib-xp-translations
-Enonic XP Library for getting all content translations
+# Enonic XP Translation Library
+
+Enonic XP Library for getting all content translations (from different layers).
+
+## Gradle
+
+To install this library you may need to add some new dependencies to your app's build.gradle file.
+
+```groovy
+repositories {
+  maven { url 'https://jitpack.io' }
+}
+
+dependencies {
+  include "com.enonic.xp:lib-context:${xpVersion}"
+  include "com.enonic.xp:lib-portal:${xpVersion}"
+  include "com.enonic.xp:lib-project:${xpVersion}"
+  include "com.enonic.xp:lib-vhost:${xpVersion}"
+  include 'no.item:lib-xp-translations:1.0.0'
+}
+```
+
+### TypeScript
+
+You can add the following changes to your *tsconfig.json* to get TypeScript-support.
+
+```diff
+{
+  "compilerOptions": {
++   "baseUrl": "./",
++   "paths": {
++     "/lib/xp/*": ["./node_modules/@enonic-types/lib-*"],
++     "/lib/*": [ "./node_modules/@item-enonic-types/lib-*" ,"./src/main/resources/lib/*"],
++   }
+  }
+}
+```
+## Usage
+
+This library exposes a function `getTranslations()` that takes a content id, and the request, and returns an
+array with urls to all translations of the content on different layers.
+
+It will return an array with objects of this shape:
+
+```typescript
+interface Translation {
+  url: string;
+  languageCode: string;
+  current: boolean;
+}
+```
+
+For pages that doesn't have a translation in a language, it will return the url of the top page of that language.
+
+### Example
+
+```typescript
+import { getContent } from "/lib/xp/portal";
+import { render } from "/lib/thymeleaf";
+import { localize } from "/lib/xp/i18n";
+import { getTranslations } from "/lib/translations";
+
+const view = resolve("default.html");
+
+export function get(req: XP.Request): XP.Response {
+  const content = getContent()!;
+  const translations = getTranslations(content._id, req)
+    .map(addName)
+  
+  return {
+    body: render(view, { translations })
+  }
+}
+
+function addName(translation: Translation): Translation & { name: string } {
+  const name = localize({
+    key: `language.${translation.languageCode}`,
+    locale: content.language ?? 'en',
+  });
+  
+  return {
+    ...translation,
+    name
+  };
+}
+```
+
+### Building
+
+To build he project run the following code
+
+```bash
+./gradlew build
+```
+
+### Deploy locally
+
+Deploy locally for testing purposes:
+
+```bash
+./gradlew publishToMavenLocal
+```
+## Deploy to Jitpack
+
+Go to the [Jitpack page for lib-xp-translations](https://jitpack.io/#no.item/lib-xp-translations) to deploy from Github (after
+[creating a new versioned release](https://github.com/ItemConsulting/lib-xp-translations/releases/new)).

--- a/src/main/resources/lib/translations/index.ts
+++ b/src/main/resources/lib/translations/index.ts
@@ -1,0 +1,114 @@
+import { list as listProjects, type Project } from "/lib/xp/project";
+import { run } from "/lib/xp/context";
+import { pageUrl } from "/lib/xp/portal";
+import { list as listVhosts, type VirtualHost } from "/lib/xp/vhost";
+import { Request } from "@item-enonic-types/global/controller";
+
+export interface Translation {
+  url: string;
+  languageCode: string;
+  current: boolean;
+}
+
+export function getTranslations(contentId: string, req: Request): Array<Translation>;
+export function getTranslations(contentId: string, currentRepositoryId: string): Array<Translation>;
+export function getTranslations(contentId: string, reqOrCurrentRepositoryId: string | Request): Array<Translation> {
+  const currentProjectId = getCurrentProjectId(reqOrCurrentRepositoryId);
+  const vhosts = listVhosts().vhosts;
+
+  return listProjects()
+    .map((project) => createTranslation(project, vhosts, contentId, currentProjectId))
+    .filter<Translation>(notNullOrUndefined)
+    .sort((a, b) => a.languageCode.localeCompare(b.languageCode));
+}
+
+function getCurrentProjectId(reqOrCurrentRepositoryId: string | Request): string {
+  const currentRepositoryId =
+    typeof reqOrCurrentRepositoryId === "string" ? reqOrCurrentRepositoryId : reqOrCurrentRepositoryId.repositoryId;
+  return getProjectIdByRepositoryId(currentRepositoryId);
+}
+
+function getProjectIdByRepositoryId(repositoryId: string): string {
+  return substringAfterLast(substringAfterLast(repositoryId, "/"), ".");
+}
+
+function substringAfterLast(str: string, search: string): string {
+  return str.substring(str.lastIndexOf(search) + 1);
+}
+
+function createTranslation(
+  project: Project,
+  vhosts: VirtualHost[],
+  contentId: string,
+  currentProjectId: string
+): Translation | undefined {
+  const rootUrl = getVhostSourceByProject(project.id, vhosts)?.source;
+  const url = getTranslatedUrl(project.id, contentId, currentProjectId, vhosts) ?? rootUrl;
+
+  return project.language && url
+    ? {
+        languageCode: project.language,
+        current: project.id === currentProjectId,
+        url,
+      }
+    : undefined;
+}
+
+function getVhostSourceByProject(projectId: string, vhosts: VirtualHost[]): VirtualHost | undefined {
+  return findVhost(vhosts, (vhost) => startsWith(vhost.target, `/site/${projectId}/`));
+}
+
+function startsWith(str: string, search: string): boolean {
+  return str.slice(0, search.length) === search;
+}
+
+function getTranslatedUrl(
+  projectId: string,
+  contentId: string,
+  currentProjectId: string,
+  vhosts: VirtualHost[]
+): string | void {
+  const currentVhost = getVhostSourceByProject(currentProjectId, vhosts);
+  const projectVhost = getVhostSourceByProject(projectId, vhosts);
+  const urlOnWrongVhost = run(
+    {
+      repository: `com.enonic.cms.${projectId}`,
+    },
+    () =>
+      pageUrl({
+        id: contentId,
+      })
+  );
+
+  if (urlIs404(urlOnWrongVhost)) {
+    return;
+  } else if (isInAdminSite(urlOnWrongVhost, vhosts)) {
+    return urlOnWrongVhost.replace(`/${currentProjectId}/draft/`, `/${projectId}/draft/`);
+  } else if (urlOnWrongVhost === currentVhost?.source && projectVhost) {
+    // is top level of translated page
+    return urlOnWrongVhost.replace(currentVhost.source, projectVhost.source);
+  } else if (currentVhost && projectVhost) {
+    return urlOnWrongVhost.replace(appendSlash(currentVhost.source), appendSlash(projectVhost.source));
+  }
+}
+
+function urlIs404(url: string): boolean {
+  return url.indexOf("/_/error/404") !== -1;
+}
+
+function isInAdminSite(url: string, vhosts: VirtualHost[]): boolean {
+  const adminSource = findVhost(vhosts, (vhost) => vhost.target === "/admin")?.source ?? "/admin";
+  return startsWith(url, adminSource);
+}
+
+function findVhost(vhosts: VirtualHost[], f: (vhost: VirtualHost) => unknown): VirtualHost | undefined {
+  return vhosts.filter(f)[0];
+}
+
+function appendSlash(path: string): string {
+  return path === "/" ? path : `${path}/`;
+}
+
+function notNullOrUndefined<T>(val: T | null | undefined): val is T {
+  return val !== null && val !== undefined;
+}


### PR DESCRIPTION
There is no built-in functionality in XP that can return a list of all versions of this content on different layers.

This library will combine projectLib with vhostLib to expose a function "getTranslations()" which will return a list of URLs for a given content on different layers.